### PR TITLE
fix: send other proxy headers even if proxy secret is undefined INTER-1158

### DIFF
--- a/src/utils/addProxyIntegrationHeaders.ts
+++ b/src/utils/addProxyIntegrationHeaders.ts
@@ -5,7 +5,8 @@ export function addProxyIntegrationHeaders(headers: Headers, url: string, env: I
   const proxySecret = getProxySecret(env)
   if (proxySecret) {
     headers.set('FPJS-Proxy-Secret', proxySecret)
-    headers.set('FPJS-Proxy-Client-IP', getClientIp())
-    headers.set('FPJS-Proxy-Forwarded-Host', new URL(url).hostname)
   }
+
+  headers.set('FPJS-Proxy-Forwarded-Host', new URL(url).hostname)
+  headers.set('FPJS-Proxy-Client-IP', getClientIp())
 }


### PR DESCRIPTION
* Proxy integration should send the other `Fpjs-proxy-*` headers even if the proxy secret is undefined. This allows the Fingerprint API to recognize the request as proxied and apply appropriate validation.
* Adjusted tests, making small improvements along the way: 
  * Tests now check if pre-existing headers are preserved.
  * Tests now check if the value of the proxy secret header matches.
  * The "correct configuration" test case comes first.
  * "No proxy secret" test makes sure the secret is not defined in the Secret store. Previous code relied on the order of test cases to work.