### PR TITLE
ci: set Datadog team in mock-e2e-daily workflow runs

### DIFF
--- a/.github/workflows/mock-e2e-daily.yml
+++ b/.github/workflows/mock-e2e-daily.yml
@@ -6,6 +6,12 @@ on:
   workflow_dispatch:
 
 jobs:
+  set_datadog_team:
+    name: 'Set Datadog team'
+    uses: fingerprintjs/dx-team-toolkit/.github/workflows/set-datadog-team.yml@v1
+    secrets:
+      DD_API_KEY: ${{ secrets.INTEGRATIONS_DATADOG_API_KEY }}
+
   build-and-test-e2e-mock:
     runs-on: ubuntu-latest
     name: Test e2e for PR using mock app
@@ -29,12 +35,3 @@ jobs:
           RESULT_PATH: ${{secrets.RESULT_PATH}}
           AGENT_PATH: ${{secrets.AGENT_PATH}}
           API_URL: ${{secrets.MOCK_FPCDN}}
-  report-status:
-    needs: build-and-test-e2e-mock
-    if: always()
-    uses: fingerprintjs/dx-team-toolkit/.github/workflows/report-workflow-status.yml@v1
-    with:
-      notification_title: 'Fastly Compute E2E Test: {status_message}'
-      job_status: ${{ needs.build-and-test-e2e-mock.result }}
-    secrets:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
- Adds a new job to the mock-e2e-daily workflow to set the Datadog team using the set-datadog-team workflow from dx-team-toolkit. This will associate workflow results with the integrations team in Datadog.
- Removes the report_status job in favor of centralizing notifications with Datadog monitors.