### PR TITLE
INTER-2089: Log build errors before exiting

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -10,4 +10,7 @@ build({
   format: 'cjs',
   external: ['fastly:*'],
   define: { 'process.env.STORE_NAME_PREFIX': `"${configStoreNamePrefix}"` },
-}).catch(() => process.exit(1))
+}).catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
- Log errors in the esbuild catch handler before calling `process.exit(1)`
- Previously, non-ESBuild JS errors did not show a stack trace.

## How To Test?

Without fix:

```
$ chmod u-x ./build
$ pnpm build
✘ [ERROR] Failed to write to output file: open <project>/build/index.js: permission denied
```

With fix:

```
$ chmod u-x ./build
$ pnpm build
✘ [ERROR] Failed to write to output file: open <project>/build/index.js: permission denied

Error: Build failed with 1 error:
error: Failed to write to output file: open <project>/build/index.js: permission denied
    at failureErrorWithLog (<project>/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:1476:15)
    at <project>/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:945:25
    at <project>/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:897:52
    at buildResponseToResult (<project>/node_modules/.pnpm/esbuild@0.24.0/node_modules/esbuild/lib/main.js:943:7)
    ...
```