### PR TITLE
fix: call isProxySecretSet instead of checking function reference

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,23 @@
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
+  $schema: 'https://json.schemastore.org/eslintrc',
   extends: ['@fingerprintjs/eslint-config-dx-team'],
   ignorePatterns: ['dist/*'],
+  overrides: [
+    {
+      files: ['**/*.ts'],
+      parserOptions: {
+        project: './tsconfig.json',
+      },
+      rules: {
+        // https://typescript-eslint.io/rules/strict-boolean-expressions/
+        '@typescript-eslint/strict-boolean-expressions': [
+          'error',
+          {
+            allowNullableString: true,
+          },
+        ],
+      },
+    },
+  ],
 }

--- a/src/handlers/handleIngressAPI.ts
+++ b/src/handlers/handleIngressAPI.ts
@@ -12,7 +12,7 @@ import { getIngressBackendByRegion } from '../utils/getIngressBackendByRegion'
 import { CacheOverride } from 'fastly:cache-override'
 
 async function makeIngressRequest(receivedRequest: Request, env: IntegrationEnv) {
-  if (!isProxySecretSet) {
+  if (!isProxySecretSet(env)) {
     console.log("PROXY_SECRET is not set in the integration's Secret store, your integration is not working correctly.")
   }
   const url = new URL(receivedRequest.url)

--- a/src/handlers/handleStatusPage.ts
+++ b/src/handlers/handleStatusPage.ts
@@ -126,7 +126,7 @@ function buildConfigurationMessage(config: ConfigurationStatus, env: Integration
     }
   }
 
-  return `<li><code>${label}</code> (${required ? 'Required' : 'Optional'}) is ${isSet ? `${showValue ? `<code>${value}</code>` : 'set'} ✅` : `${required ? 'missing ❌' : 'not set ⚠️'}`}. ${message ?? ''}</li>`
+  return `<li><code>${label}</code> (${required ? 'Required' : 'Optional'}) is ${isSet ? `${showValue === true ? `<code>${value}</code>` : 'set'} ✅` : `${required ? 'missing ❌' : 'not set ⚠️'}`}. ${message ?? ''}</li>`
 }
 
 async function buildKVStoreCheckMessage(): Promise<string> {


### PR DESCRIPTION
## Summary

- Fix `isProxySecretSet` being checked as a function reference (always truthy) instead of called with `env`, so the proxy secret warning log now fires correctly when `PROXY_SECRET` is missing.
- Add `@typescript-eslint/strict-boolean-expressions` ESLint rule to catch this class of bug statically.

[INTER-2087](https://fingerprintjs.atlassian.net/browse/INTER-2087)

[INTER-2087]: https://fingerprintjs.atlassian.net/browse/INTER-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ