### PR TITLE
INTER-2208: Truncate E2E subdomain to prevent label limit

### DIFF
--- a/.github/workflows/mock-e2e-pr.yml
+++ b/.github/workflows/mock-e2e-pr.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Extract Branch Name
         id: extract-branch
         run: |
-          echo SUBDOMAIN=mock-$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | perl -pe 's/[^a-zA-Z0-9]+/-/g and s/-+$//g' | tr '[:upper:]' '[:lower:]') >> $GITHUB_OUTPUT
+          echo SUBDOMAIN=mock-$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | perl -pe 's/[^a-zA-Z0-9]+/-/g and s/-+$//g' | tr '[:upper:]' '[:lower:]' | cut -c1-46 | sed 's/-$//') >> $GITHUB_OUTPUT
       - name: Set up Fastly CLI
         uses: fastly/compute-actions/setup@v8
       - name: Package Fastly WASM File

--- a/.github/workflows/mock-e2e-pr.yml
+++ b/.github/workflows/mock-e2e-pr.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Extract Branch Name
         id: extract-branch
         run: |
-          echo SUBDOMAIN=mock-$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | perl -pe 's/[^a-zA-Z0-9]+/-/g and s/-+$//g' | tr '[:upper:]' '[:lower:]' | cut -c1-46 | sed 's/-$//') >> $GITHUB_OUTPUT
+          branch=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}} | perl -pe 's/[^a-zA-Z0-9]+/-/g and s/-+$//g' | tr '[:upper:]' '[:lower:]')
+          hash=$(echo "$branch" | cksum | awk '{printf "%08x", $1}')
+          truncated=$(echo "$branch" | cut -c1-37 | sed 's/-$//')
+          echo SUBDOMAIN=mock-${truncated}-${hash} >> $GITHUB_OUTPUT
       - name: Set up Fastly CLI
         uses: fastly/compute-actions/setup@v8
       - name: Package Fastly WASM File


### PR DESCRIPTION
The E2E workflow derives a Fastly domain from the branch name: `fpjs-fastly-{subdomain}.edgecompute.app`.

DNS labels have a hard limit of **63 characters** (the table says longer than 64 characters, but it also errors at exactly 64 characters). Long branch names push the label over this limit, causing Fastly's API to reject the domain:

> Not a valid domain name: 'fpjs-fastly-mock-feat-remove-ocr-add-fingerprint-backend-inter-2098.edgecompute.app'

`invalid` status can also be reviewed from [this table in the Fastly documentation](https://www.fastly.com/documentation/reference/api/domain-management/domain-research/#status-response-values).

> | Status | Example | Documentation |
> | --- | --- | --- |
> | ... | ... | ... |
> | `invalid` | A domain longer than 64 characters | Technically invalid, e.g. too long or too short. |
> | ... | ... | ... |

---

CRC32 was chosen over SHA256 because cryptographic strength isn't needed here. Just collision protection for short strings, and CRC32 is **significantly cheaper** to compute.
