### PR TITLE
Use paths-changed action for mock e2e gating

### DIFF
--- a/.github/workflows/mock-e2e-pr.yml
+++ b/.github/workflows/mock-e2e-pr.yml
@@ -7,28 +7,22 @@ jobs:
   check-changed-files:
     runs-on: ubuntu-latest
     name: Check changed files
+    permissions:
+      contents: read
     outputs:
-      NEED_TO_RUN_TESTS: ${{ steps.decision.outputs.NEED_TO_RUN_TESTS }}
+      NEED_TO_RUN_TESTS: ${{ steps.changes.outputs.changed }}
     steps:
-      - name: Git clone
-        uses: actions/checkout@v4
-      - name: Get changed files
-        id: decision
+      - uses: actions/checkout@v4
+      - id: changes
+        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@main
+        with:
+          paths: |
+            src/**
+            plugins/**
+            .github/workflows/**
+      - name: Print decision
         run: |
-          git fetch origin $GITHUB_BASE_REF
-          diff=$(git diff --name-only origin/$GITHUB_BASE_REF..HEAD)
-          echo $diff
-          needToRunTests=false
-          for changed_file in $diff; do
-            if [[ ${changed_file} =~ ^(src|plugins)\/.+$ ]]; then
-              needToRunTests=true
-            fi
-            if [[ ${changed_file} =~ ^\.github\/workflows\/.+$ ]]; then
-              needToRunTests=true
-            fi
-          done
-          echo $needToRunTests
-          echo NEED_TO_RUN_TESTS=${needToRunTests} >> $GITHUB_OUTPUT
+          echo "NEED_TO_RUN_TESTS=${{ steps.changes.outputs.changed }}"
   build-and-test-e2e-mock:
     runs-on: ubuntu-latest
     name: Test e2e for PR using mock app

--- a/.github/workflows/mock-e2e-pr.yml
+++ b/.github/workflows/mock-e2e-pr.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: changes
-        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@main
+        uses: fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1
         with:
           paths: |
             src/**


### PR DESCRIPTION
- Replaces the custom changed-file shell loop with `fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1`.
- Keeps the existing `NEED_TO_RUN_TESTS` job output used by the mock e2e job.
- Logs the action decision in CI so the output is visible in run logs.

### Validation

- Workflow YAML parsed locally with Ruby.
- `dx-team-toolkit` now has `v1.4.0`; moving `v1` points to `24f435b05bf59b3b78e2c0eee1eb1e3195743c59`.
- [`Check changed files`](https://github.com/fingerprintjs/fastly-compute-proxy/actions/runs/27709863560/job/81967842082) passed using `fingerprintjs/dx-team-toolkit/.github/actions/paths-changed@v1`.
- The same run shows the downstream [`Test e2e for PR using mock app`](https://github.com/fingerprintjs/fastly-compute-proxy/actions/runs/27709863560/job/81967864782) started, proving the job output gated correctly.

### Known CI State

The previous run proved the downstream mock e2e deploy can fail with Fastly `Exceeding max_config_stores: 5` after the gating job succeeds. That is unrelated to changed-file detection.